### PR TITLE
Added support for Arch ISO

### DIFF
--- a/fix_my_wifi.sh
+++ b/fix_my_wifi.sh
@@ -26,15 +26,19 @@ set -e
 
 # Variables declaration
 SCRIPT_DIR=$(pwd)
-BT_DIR="../linux-$(uname -r | cut -d'.' -f1,2)/drivers/bluetooth"
+KERNEL_VER=$(uname -r)
+IS_CACHYOS=false
+IS_ARCH=false
+BT_DIR="$SCRIPT_DIR/linux-$KERNEL_VER/drivers/bluetooth"
 
-if [[ "$(uname -r)" == *"cachyos"* ]]; then
+if [[ "$KERNEL_VER" == *"cachyos"* ]]; then
     IS_CACHYOS=true
-else
-    IS_CACHYOS=false
 fi
 
-# Usage Check: Ensure script is run with sudo
+if [[ "$KERNEL_VER" == *"arch"* ]]; then
+    IS_ARCH=true
+fi
+
 if [[ $EUID -ne 0 ]]; then
     echo "❌ This script must be run as root (use sudo)."
     echo "Usage: sudo ./fix_my_wifi.sh"
@@ -48,18 +52,18 @@ echo "🚀 Starting MT7902 Fix..."
 if [ -f /etc/debian_version ]; then
     echo "📦 Checking prerequisites..."
     apt-get update
-    apt-get install -y build-essential linux-headers-$(uname -r) bc
+    apt-get install -y build-essential linux-headers-$KERNEL_VER bc
 fi
 
-# For CachyOS
-if $IS_CACHYOS; then
-    pacman -S clang llvm lld
+# For CachyOS and Arch
+if $IS_ARCH || $IS_CACHYOS; then
+  sudo pacman -S --noconfirm clang llvm lld linux-headers base-devel
 fi
 
 # 2. Compile WiFi Modules
 echo "🛠️ Compiling WiFi modules..."
 cd "$SCRIPT_DIR/latest"
-make clean
+make clean || echo "No clean target for WiFi, continuing..."
 if $IS_CACHYOS; then
     make CC=clang LD=ld.lld module_compile
 else
@@ -70,7 +74,7 @@ fi
 echo "🛠️ Compiling Bluetooth modules..."
 if [ -d "$BT_DIR" ]; then
     cd "$BT_DIR"
-    make clean
+    make clean || echo "No clean target for BT, continuing..."
     if $IS_CACHYOS; then
         make CC=clang LD=ld.lld
     else
@@ -82,10 +86,11 @@ fi
 
 # 4. Prepare and Copy Modules
 echo "📂 Installing modules..."
-cd "$SCRIPT_DIR/latest"
-mkdir -p /lib/modules/mt7902_custom/
-cp *.ko /lib/modules/mt7902_custom/
-cp mt7921/*.ko /lib/modules/mt7902_custom/
+MODULE_DIR="/lib/modules/mt7902_custom"
+mkdir -p "$MODULE_DIR"
+cd  "$SCRIPT_DIR/latest"
+cp *.ko "$MODULE_DIR/"
+cp mt7921/*.ko "$MODULE_DIR/"
 
 if [ -d "$BT_DIR" ]; then
     cd "$BT_DIR"
@@ -97,7 +102,7 @@ echo "📝 Configuring startup service..."
 cat <<EOF | tee /usr/local/bin/mt7902-setup.sh
 #!/bin/bash
 # Unload conflicting modules
-rmmod btusb btmtk mt7921e mt7921_common mt792x_lib mt76_connac_lib mt76 2>/dev/null
+rmmod btusb btmtk mt7921e mt7921_common mt792x_lib mt76_connac_lib mt76 2>/dev/null || true
 
 # Load WiFi stack
 modprobe cfg80211
@@ -110,19 +115,17 @@ insmod /lib/modules/mt7902_custom/mt792x-lib.ko
 insmod /lib/modules/mt7902_custom/mt7921-common.ko
 insmod /lib/modules/mt7902_custom/mt7921e.ko
 
-
+# Load Blutetooth stack if modules exist
 if [ -f /lib/modules/mt7902_custom/btmtk.ko ]; then
-    # Load Bluetooth stack
     modprobe bluetooth
     modprobe btrtl
     modprobe btintel
     modprobe btbcm
 
-    # Load custom MT7902 modules (Bluetooth)
     insmod /lib/modules/mt7902_custom/btmtk.ko
     insmod /lib/modules/mt7902_custom/btusb.ko
 
-    systemctl restart bluetooth
+    systemctl restart bluetooth || true
 fi
 EOF
 
@@ -147,4 +150,4 @@ systemctl daemon-reload
 systemctl enable mt7902.service
 systemctl restart mt7902.service
 
-echo "✅ MT7902 is now active! Your WiFi should be working."
+echo "✅ MT7902 is now active! Your WiFi and Bluetooth should be working."

--- a/fix_my_wifi.sh
+++ b/fix_my_wifi.sh
@@ -39,6 +39,7 @@ if [[ "$KERNEL_VER" == *"arch"* ]]; then
     IS_ARCH=true
 fi
 
+# Usage Check: Ensure script is run with sudo
 if [[ $EUID -ne 0 ]]; then
     echo "❌ This script must be run as root (use sudo)."
     echo "Usage: sudo ./fix_my_wifi.sh"


### PR DESCRIPTION
First I wanna say that I LOVE your efforts, as I got both wifi and bluetooth working on my ASUS laptop using the mt7902 chip (so far, flawlessly)

The edits in here focus on fixing halts that would happen when trying to install in a minimal chroot when running the Arch install process via the Arch ISO.

Similar to the pre-existing IS_CACHYOS, I implemented IS_ARCH. I would have liked to make it more general and encompassing of other Arch-derivatives, but I am just not familiar enough to confidentially do it.

The other changes are better use of constant variables (such as directories or kernel versions) as well as trying to prevent the program from halting in case something fails. 
