### PR TITLE
expand distro support with multi-package manager detection and automatic compiler selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ This fix has been verified and is confirmed working on:
 
 ## Available for:
 * **OS**: Any os that support one of PM`s
-* **Package Managers needs to work**: apt, pacman, dnf, zypper, nix-shell
+* **Preffered package managers**: apt, pacman, dnf, zypper, nix-shell
+* **Kernel versions**: 6.14-6.19
 
 ## 🚀 Easy Automatic Fix (Recommended)
 If you want to quickly fix your WiFi and Bluetooth on any modern kernel, follow these steps:
@@ -30,13 +31,13 @@ If you want to quickly fix your WiFi and Bluetooth on any modern kernel, follow 
    ```
 
 ### 📖 What this script does:
-* **Checks for dependencies:** Ensures you have `gcc`/`clang`, `make`, `bc`, and your current `kernel-headers` installed. If not - installs with ur PM
+* **Checks for dependencies:** Ensures you have `gcc`/`clang`, `make`, `bc`, and your current `kernel-headers` installed. If not - installs with ur preffered package manager
 * **Compiles Drivers:** Automatically builds both WiFi and Bluetooth drivers for your exact kernel version.
 * **Persistent Fix:** Installs a system service that ensures your WiFi stays active even after you restart your computer.
 * **Safety:** Installs modules into a custom directory (`/lib/modules/mt7902_custom`) to avoid messing with your default system files.
 
 > [!NOTE]
-> You will need an internet connection (via Ethernet or USB tethering from your phone) the first time you run this to download the necessary build tools.
+> You will need an internet connection (via Ethernet or USB tethering from your phone) the first time you run this to download the necessary build tools. (Such as compilator, linux-headers, etc)
 
 ## 🔧 Firmwares used
 Firmwares are stored in `mt7902_firmware` folder.

--- a/README.md
+++ b/README.md
@@ -5,10 +5,15 @@ We are trying to develop the driver for the Mediatek mt7902 wifi 6E chip
 This fix has been verified and is confirmed working on:
 
 * **Brand:** ASUS
-* **Model:** Vivobook Go (E1404FA)
+* **Model:** Vivobook Go (E1404FA), Vivobook 14 (X1404ZA)
 * **Chipset:** MediaTek MT7902 (WiFi 6E)
-* **Kernel Version:** 6.19.0 (Linux)
-* **OS:** Ubuntu 24.04 (or similar Debian-based distros)
+* **Kernel Version:** 6.19.0 (Linux), 6.19.11
+* **OSes:** Arch, Ubuntu
+* **Package Manager:** pacman, apt
+
+## Available for:
+* **OS**: Any os that support one of PM`s
+* **Package Managers needs to work**: apt, pacman, dnf, zypper, nix-shell
 
 ## 🚀 Easy Automatic Fix (Recommended)
 If you want to quickly fix your WiFi and Bluetooth on any modern kernel, follow these steps:
@@ -25,7 +30,7 @@ If you want to quickly fix your WiFi and Bluetooth on any modern kernel, follow 
    ```
 
 ### 📖 What this script does:
-* **Checks for dependencies:** Ensures you have `gcc`, `make`, and your current `kernel-headers` installed.
+* **Checks for dependencies:** Ensures you have `gcc`/`clang`, `make`, `bc`, and your current `kernel-headers` installed. If not - installs with ur PM
 * **Compiles Drivers:** Automatically builds both WiFi and Bluetooth drivers for your exact kernel version.
 * **Persistent Fix:** Installs a system service that ensures your WiFi stays active even after you restart your computer.
 * **Safety:** Installs modules into a custom directory (`/lib/modules/mt7902_custom`) to avoid messing with your default system files.

--- a/fix_my_wifi.sh
+++ b/fix_my_wifi.sh
@@ -28,12 +28,6 @@ set -e
 SCRIPT_DIR=$(pwd)
 BT_DIR="../linux-$(uname -r | cut -d'.' -f1,2)/drivers/bluetooth"
 
-if [[ "$(uname -r)" == *"cachyos"* ]]; then
-    IS_CACHYOS=true
-else
-    IS_CACHYOS=false
-fi
-
 # Usage Check: Ensure script is run with sudo
 if [[ $EUID -ne 0 ]]; then
     echo "❌ This script must be run as root (use sudo)."
@@ -43,39 +37,44 @@ fi
 
 echo "🚀 Starting MT7902 Fix..."
 
-# 1. Install prerequisites
-# For Ubuntu/Debian
-if [ -f /etc/debian_version ]; then
-    echo "📦 Checking prerequisites..."
+if command -v apt &> /dev/null; then
     apt-get update
-    apt-get install -y build-essential linux-headers-$(uname -r) bc
+    apt-get install -y build-essential linux-headers-$(uname -r) bc clang llvm lld
+elif command -v pacman &> /dev/null; then
+    pacman -Sy --needed --noconfirm base-devel linux-headers bc clang llvm lld
+elif command -v dnf &> /dev/null; then
+    dnf install -y @development-tools kernel-devel-$(uname -r) bc clang llvm lld
+elif command -v zypper &> /dev/null; then
+    zypper install -y -t pattern devel_basis
+    zypper install -y kernel-default-devel bc clang llvm lld
+elif command -v nix-shell &> /dev/null; then
+    nix-shell -p linuxHeaders.$(uname -r) bc clang llvm lld    
+else
+    echo "⚠️ No supported package manager found (apt, pacman, dnf, zypper, nix-shell)."
+    echo "Please install make, gcc/clang, flex, bison, bc and kernel headers manually."
 fi
 
-# For CachyOS
-if $IS_CACHYOS; then
-    pacman -S clang llvm lld
+# Detect kernel compiler
+if grep -qi "clang" /proc/version; then
+    echo "🔍 Clang compiled kernel detected. Using Clang for module."
+    COMPILER_ARGS="CC=clang LD=ld.lld"
+else if grep -qi "gcc" /proc/version; then
+    echo "🔍 GCC compiled kernel detected. Using GCC for module."
+    COMPILER_ARGS="CC=gcc LD=gcc"
 fi
 
 # 2. Compile WiFi Modules
 echo "🛠️ Compiling WiFi modules..."
 cd "$SCRIPT_DIR/latest"
 make clean
-if $IS_CACHYOS; then
-    make CC=clang LD=ld.lld module_compile
-else
-    make module_compile
-fi
+make $COMPILER_ARGS module_compile
 
 # 3. Compile Bluetooth Modules
 echo "🛠️ Compiling Bluetooth modules..."
 if [ -d "$BT_DIR" ]; then
     cd "$BT_DIR"
     make clean
-    if $IS_CACHYOS; then
-        make CC=clang LD=ld.lld
-    else
-        make
-    fi
+    make $COMPILER_ARGS
 else
     echo "⚠️ Bluetooth source not found for this kernel version, skipping BT build."
 fi
@@ -144,7 +143,7 @@ WantedBy=multi-user.target
 EOF
 
 systemctl daemon-reload
-systemctl enable mt7902.service
+systemctl enable --now mt7902.service
 systemctl restart mt7902.service
 
 echo "✅ MT7902 is now active! Your WiFi should be working."

--- a/fix_my_wifi.sh
+++ b/fix_my_wifi.sh
@@ -81,6 +81,7 @@ fi
 
 # 4. Prepare and Copy Modules
 echo "📂 Installing modules..."
+
 cd "$SCRIPT_DIR/latest"
 mkdir -p /lib/modules/mt7902_custom/
 cp *.ko /lib/modules/mt7902_custom/

--- a/fix_my_wifi.sh
+++ b/fix_my_wifi.sh
@@ -58,9 +58,9 @@ fi
 if grep -qi "clang" /proc/version; then
     echo "🔍 Clang compiled kernel detected. Using Clang for module."
     COMPILER_ARGS="CC=clang LD=ld.lld"
-else if grep -qi "gcc" /proc/version; then
+elif grep -qi "gcc" /proc/version; then
     echo "🔍 GCC compiled kernel detected. Using GCC for module."
-    COMPILER_ARGS="CC=gcc LD=gcc"
+    COMPILER_ARGS="CC=gcc "
 fi
 
 # 2. Compile WiFi Modules


### PR DESCRIPTION
Expanding PR that adds support for big percent of OSes.

Yesterday I wanted to install drivers for my Arch laptop, but I had to manually rewrite the driver installation script. I modified it so it would work not only on Debian-based systems and CachyOS, but also on Nix, Arch-based systems, and others, with the package managers and os compilers described in the README.md installed.