### PR TITLE
fix: replace pp_page_to_nmdesc with __netmem_get_pp for kernel >= 6.17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,91 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  # ------------------------------------------------------------------ #
+  # Job 1: Static checks — no kernel headers needed, fast               #
+  # ------------------------------------------------------------------ #
+  static-checks:
+    name: Static API compatibility checks
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run check_api_compat.sh
+        run: bash tests/check_api_compat.sh
+
+  # ------------------------------------------------------------------ #
+  # Job 2: Build — compile the out-of-tree modules                      #
+  # ------------------------------------------------------------------ #
+  build:
+    name: Build kernel modules (Ubuntu 24.04 HWE)
+    runs-on: ubuntu-24.04
+    needs: static-checks
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kernel headers and build tools
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            build-essential \
+            linux-headers-generic-hwe-24.04
+
+      - name: Resolve installed kernel version
+        id: kver
+        run: |
+          KVER=$(ls /lib/modules/ | sort -V | tail -1)
+          echo "kver=$KVER" >> "$GITHUB_OUTPUT"
+          echo "Building against kernel $KVER"
+
+      - name: Verify __netmem_get_pp is available in these headers
+        run: |
+          KVER="${{ steps.kver.outputs.kver }}"
+          if ! grep -rq '__netmem_get_pp\|page_to_netmem' /lib/modules/"$KVER"/build/include/ 2>/dev/null; then
+            echo "WARNING: __netmem_get_pp not found in kernel $KVER headers."
+            echo "These headers pre-date the 6.17 API change — build may fail."
+            echo "This is expected on older runners; the fix still applies to >=6.17."
+          fi
+
+      - name: Build out-of-tree modules
+        run: |
+          KVER="${{ steps.kver.outputs.kver }}"
+          make -C /lib/modules/"$KVER"/build \
+               M="$(pwd)/latest" \
+               modules \
+               -j"$(nproc)"
+
+      - name: Verify .ko files were produced
+        run: |
+          echo "Checking for expected .ko files:"
+          MISSING=0
+          for ko in \
+            latest/mt76.ko \
+            latest/mt76-connac-lib.ko \
+            latest/mt792x-lib.ko \
+            latest/mt7921/mt7921-common.ko \
+            latest/mt7921/mt7921e.ko
+          do
+            if [ -f "$ko" ]; then
+              echo "  FOUND: $ko"
+            else
+              echo "  MISSING: $ko"
+              MISSING=$((MISSING + 1))
+            fi
+          done
+          [ "$MISSING" -eq 0 ]
+
+      - name: Check MT7902 PCI ID is embedded in mt7921e.ko
+        run: |
+          # The PCI device table is baked into the .ko ELF; confirm 7902 is there.
+          if strings latest/mt7921/mt7921e.ko | grep -q "7902"; then
+            echo "PASS: MT7902 reference found in mt7921e.ko"
+          else
+            echo "FAIL: MT7902 reference NOT found in mt7921e.ko"
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     name: Static API compatibility checks
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run check_api_compat.sh
         run: bash tests/check_api_compat.sh
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs: static-checks
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install kernel headers and build tools
         run: |

--- a/latest/mt76.h
+++ b/latest/mt76.h
@@ -2005,7 +2005,7 @@ static inline void mt76_put_page_pool_buf(void *buf, bool allow_direct)
 {
 	struct page *page = virt_to_head_page(buf);
 
-	page_pool_put_full_page(pp_page_to_nmdesc(page)->pp, page,
+	page_pool_put_full_page(__netmem_get_pp(page_to_netmem(page)), page,
 				allow_direct);
 }
 

--- a/tests/check_api_compat.sh
+++ b/tests/check_api_compat.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Static regression checks for the MT7902 driver patch set.
+# Exit 0 = all checks pass.  Exit 1 = at least one check failed.
+# Run from the repo root or pass the repo root as $1.
+set -euo pipefail
+
+ROOT="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+LATEST="$ROOT/latest"
+PASS=0
+FAIL=0
+
+check_absent() {
+    local pattern="$1" dir="${2:-$LATEST}"
+    if grep -rq "$pattern" "$dir" 2>/dev/null; then
+        echo "FAIL: '$pattern' found in $dir (should be absent)"
+        FAIL=$((FAIL + 1))
+    else
+        echo "PASS: '$pattern' absent from $dir"
+        PASS=$((PASS + 1))
+    fi
+}
+
+check_present() {
+    local pattern="$1" file="$2"
+    if grep -q "$pattern" "$file" 2>/dev/null; then
+        echo "PASS: '$pattern' found in $file"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: '$pattern' not found in $file"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+echo "=== MT7902 API compatibility checks ==="
+echo "Source tree: $LATEST"
+echo
+
+# The old page-pool API removed in kernel >=6.17 must not appear anywhere.
+check_absent "pp_page_to_nmdesc" "$LATEST"
+
+# The replacement API must be present in mt76.h.
+check_present "__netmem_get_pp"        "$LATEST/mt76.h"
+check_present "page_to_netmem"         "$LATEST/mt76.h"
+
+# MT7902 PCI device ID must be registered.
+check_present "0x7902"                 "$LATEST/mt7921/pci.c"
+
+# Firmware filenames must be defined.
+check_present "WIFI_RAM_CODE_MT7902_1.bin"        "$LATEST/mt792x.h"
+check_present "WIFI_MT7902_patch_mcu_1_1_hdr.bin" "$LATEST/mt792x.h"
+
+# Makefile must have a build target.
+check_present "module_compile"         "$LATEST/Makefile"
+
+echo
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
pp_page_to_nmdesc() was removed from the kernel page_pool API in 6.17. The equivalent call in 6.17+ is:

  __netmem_get_pp(page_to_netmem(page))

Tested on Ubuntu 24.04 with kernel 6.17.0-23-generic and MT7902 PCIe (PCI ID 14c3:7902). The driver builds cleanly and the chip initialises fully (firmware loads, wlp2s0 appears, SSIDs visible).

Fixes build error:
  mt76.h: error: implicit declaration of function 'pp_page_to_nmdesc'