### PR TITLE
fix: SCRIPT_DIR variable missing $ sign on line 29

### DIFF
--- a/fix_my_wifi.sh
+++ b/fix_my_wifi.sh
@@ -26,7 +26,7 @@ set -e
 
 # Variables declaration
 SCRIPT_DIR=$(pwd)
-LINUX_DIR="$(SCRIPT_DIR)/linux-$(uname -r | cut -d'.' -f1,2)"
+LINUX_DIR="$SCRIPT_DIR/linux-$(uname -r | cut -d'.' -f1,2)"
 BT_DIR="$LINUX_DIR/drivers/bluetooth"
 WIFI_DIR="$LINUX_DIR/drivers/net/wireless/mediatek/mt76" # SIXSEVENNN (cringe)
 


### PR DESCRIPTION
## Bug Fix

Line 29 of `fix_my_wifi.sh` ---- `$` sign is missing before `SCRIPT_DIR`, causing bash to interpret it as a command instead of a variable, which makes the script fail immediately with:

bash: SCRIPT_DIR: command not found

**Before:**
LINUX_DIR="$(SCRIPT_DIR)/linux-$(uname -r | cut -d'.' -f1,2)"

**After:**
LINUX_DIR="$SCRIPT_DIR/linux-$(uname -r | cut -d'.' -f1,2)"

Tested on Debian 13 Trixie with kernel 7.0.7 and MediaTek MT7902 chip.