### PR TITLE
fix: NULL pointer dereference kernel panic on channel switch (CSA)

### DIFF
--- a/linux-6.14/drivers/net/wireless/mediatek/mt76/mt7921/main.c
+++ b/linux-6.14/drivers/net/wireless/mediatek/mt76/mt7921/main.c
@@ -1487,6 +1487,9 @@ static void mt7921_channel_switch_rx_beacon(struct ieee80211_hw *hw,
 	struct mt792x_vif *mvif = (struct mt792x_vif *)vif->drv_priv;
 	u16 beacon_interval = vif->bss_conf.beacon_int;
 
+	if (!dev->new_ctx)
+		return;
+
 	if (cfg80211_chandef_identical(&chsw->chandef,
 				       &dev->new_ctx->def) &&
 				       chsw->count) {

--- a/linux-6.15/drivers/net/wireless/mediatek/mt76/mt7921/main.c
+++ b/linux-6.15/drivers/net/wireless/mediatek/mt76/mt7921/main.c
@@ -1488,6 +1488,9 @@ static void mt7921_channel_switch_rx_beacon(struct ieee80211_hw *hw,
 	struct mt792x_vif *mvif = (struct mt792x_vif *)vif->drv_priv;
 	u16 beacon_interval = vif->bss_conf.beacon_int;
 
+	if (!dev->new_ctx)
+		return;
+
 	if (cfg80211_chandef_identical(&chsw->chandef,
 				       &dev->new_ctx->def) &&
 				       chsw->count) {

--- a/linux-6.16/drivers/net/wireless/mediatek/mt76/mt7921/main.c
+++ b/linux-6.16/drivers/net/wireless/mediatek/mt76/mt7921/main.c
@@ -1496,6 +1496,9 @@ static void mt7921_channel_switch_rx_beacon(struct ieee80211_hw *hw,
 	struct mt792x_vif *mvif = (struct mt792x_vif *)vif->drv_priv;
 	u16 beacon_interval = vif->bss_conf.beacon_int;
 
+	if (!dev->new_ctx)
+		return;
+
 	if (cfg80211_chandef_identical(&chsw->chandef,
 				       &dev->new_ctx->def) &&
 				       chsw->count) {

--- a/linux-6.17/drivers/net/wireless/mediatek/mt76/mt7921/main.c
+++ b/linux-6.17/drivers/net/wireless/mediatek/mt76/mt7921/main.c
@@ -1497,6 +1497,9 @@ static void mt7921_channel_switch_rx_beacon(struct ieee80211_hw *hw,
 	struct mt792x_vif *mvif = (struct mt792x_vif *)vif->drv_priv;
 	u16 beacon_interval = vif->bss_conf.beacon_int;
 
+	if (!dev->new_ctx)
+		return;
+
 	if (cfg80211_chandef_identical(&chsw->chandef,
 				       &dev->new_ctx->def) &&
 				       chsw->count) {

--- a/linux-6.18/drivers/net/wireless/mediatek/mt76/mt7921/main.c
+++ b/linux-6.18/drivers/net/wireless/mediatek/mt76/mt7921/main.c
@@ -1497,6 +1497,9 @@ static void mt7921_channel_switch_rx_beacon(struct ieee80211_hw *hw,
 	struct mt792x_vif *mvif = (struct mt792x_vif *)vif->drv_priv;
 	u16 beacon_interval = vif->bss_conf.beacon_int;
 
+	if (!dev->new_ctx)
+		return;
+
 	if (cfg80211_chandef_identical(&chsw->chandef,
 				       &dev->new_ctx->def) &&
 				       chsw->count) {

--- a/linux-6.19/drivers/net/wireless/mediatek/mt76/mt7921/main.c
+++ b/linux-6.19/drivers/net/wireless/mediatek/mt76/mt7921/main.c
@@ -1497,6 +1497,9 @@ static void mt7921_channel_switch_rx_beacon(struct ieee80211_hw *hw,
 	struct mt792x_vif *mvif = (struct mt792x_vif *)vif->drv_priv;
 	u16 beacon_interval = vif->bss_conf.beacon_int;
 
+	if (!dev->new_ctx)
+		return;
+
 	if (cfg80211_chandef_identical(&chsw->chandef,
 				       &dev->new_ctx->def) &&
 				       chsw->count) {

--- a/linux-7.0/drivers/net/wireless/mediatek/mt76/mt7921/main.c
+++ b/linux-7.0/drivers/net/wireless/mediatek/mt76/mt7921/main.c
@@ -1497,6 +1497,9 @@ static void mt7921_channel_switch_rx_beacon(struct ieee80211_hw *hw,
 	struct mt792x_vif *mvif = (struct mt792x_vif *)vif->drv_priv;
 	u16 beacon_interval = vif->bss_conf.beacon_int;
 
+	if (!dev->new_ctx)
+		return;
+
 	if (cfg80211_chandef_identical(&chsw->chandef,
 				       &dev->new_ctx->def) &&
 				       chsw->count) {

--- a/linux-7.0/drivers/net/wireless/mediatek/mt76_new/mt7921/main.c
+++ b/linux-7.0/drivers/net/wireless/mediatek/mt76_new/mt7921/main.c
@@ -1643,6 +1643,9 @@ static void mt7921_channel_switch_rx_beacon(struct ieee80211_hw *hw,
 	struct mt792x_vif *mvif = (struct mt792x_vif *)vif->drv_priv;
 	u16 beacon_interval = vif->bss_conf.beacon_int;
 
+	if (!dev->new_ctx)
+		return;
+
 	if (cfg80211_chandef_identical(&chsw->chandef,
 				       &dev->new_ctx->def) &&
 				       chsw->count) {


### PR DESCRIPTION
## Bug Description

When the AP initiates a Channel Switch Announcement (CSA), the driver crashes with a kernel panic due to a NULL pointer dereference in `mt7921_channel_switch_rx_beacon`.

## Root Cause

The function dereferences `dev->new_ctx->def` without checking if `dev->new_ctx` is non-NULL:

```c
if (cfg80211_chandef_identical(&chsw->chandef,
                               &dev->new_ctx->def) &&  // ← NULL deref → KERNEL PANIC
                               chsw->count) {
```

`dev->new_ctx` is only set in `add_chanctx()` and cleared in `remove_chanctx()`. Under normal operation this is fine, but if the channel context is freed during a race condition, or the context was never properly allocated, `dev->new_ctx` is NULL and the kernel crashes. The system becomes completely unresponsive, requiring a forced power-off.

## Fix

Add an early return guard before the NULL dereference:

```c
if (!dev->new_ctx)
        return;
```

This matches the defensive pattern already used in `mt76_connac_mcu_uni_set_chctx()` (line 1463) which safely handles a NULL `ctx` parameter with a fallback.

## Affected Files

All kernel version variants of the driver (6.14 - 7.0), 8 files total, 24 lines changed.

## Tested

Verified on kernel 6.18.7 with a Mediatek MT7902 (PCI ID 14c3:7902). Module loads and WiFi operates normally. The crash no longer occurs during CSA events.