### PR TITLE
Add ASUS Vivobook (M1502YA) to tested devices, document immutable/ost…

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,19 @@ sudo bash fix_my_wifi.sh
 This fix has been verified and is confirmed working on:
 
 * **Brand:** ASUS
-* **Model:** Vivobook Go (E1404FA), Vivobook 14 (X1404ZA)
+* **Model:** Vivobook Go (E1404FA), Vivobook 14 (X1404ZA), Vivobook (M1502YA)
 * **Chipset:** MediaTek MT7902 (WiFi 6E)
-* **Kernel Version:** 6.19.0 (Linux), 6.19.11, 7.0.7
-* **OSes:** Arch, Ubuntu
-* **Package Manager:** pacman, apt
+* **Kernel Version:** 6.19.0 (Linux), 6.19.11, 6.19.14, 7.0.7
+* **OSes:** Arch, Ubuntu, Bazzite (Fedora Silverblue-based, immutable/ostree)
+* **Package Manager:** pacman, apt, rpm-ostree (build-only, see note below)
+
+> [!NOTE]
+> **Immutable/ostree distros (Bazzite, Silverblue, uCore, etc.):** `/lib/modules` is read-only, so
+> `fix_my_wifi.sh`'s `/lib/modules/mt7902_custom` target isn't writable — install to `/var/lib/mt7902_modules`
+> instead (persists across `rpm-ostree` updates). With SELinux enforcing, loading a module from that path
+> is denied (`avc: denied { module_load } ... tcontext=var_lib_t`) unless you relabel it first:
+> `sudo semanage fcontext -a -t modules_object_t '/var/lib/mt7902_modules(/.*)?' && sudo restorecon -R /var/lib/mt7902_modules`.
+> Everything else (build against matched `kernel-devel`, firmware, systemd service) works as documented.
 
 ## Available for:
 * **OS**: Any os that support one of PM`s


### PR DESCRIPTION
## Summary
- Add **ASUS Vivobook (M1502YA)** to the "Tested On" list, confirming the MT7902 driver works on this model too (AMD Barcelo APU).
- Add kernel `6.19.14` and **Bazzite** (Fedora Silverblue-based, immutable/ostree) to the tested versions/OSes.
- Document the extra steps needed on immutable/ostree distros, since `fix_my_wifi.sh` assumes a traditional writable `/lib/modules`:
  - `/lib/modules` is read-only there, so install the compiled `.ko` files to `/var/lib/mt7902_modules` instead (persists across `rpm-ostree` updates).
  - With SELinux enforcing, loading a module from that path is denied (`avc: denied { module_load } ... tcontext=var_lib_t`) unless relabeled first with `semanage fcontext` + `restorecon`.

## Testing
- Built the driver from `linux-6.19/drivers/net/wireless/mediatek/mt76` against matching `kernel-devel`.
- Verified `mt7921e` binds to PCI id `7902`, firmware loads, `wlp1s0` comes up, WPA2 scan/associate/DHCP all work.
- Set up as a systemd service so it persists across reboots (WiFi only, didn't touch Bluetooth).

No code changes, README only.