### PR TITLE
btusb: Add Foxconn MT7902 Bluetooth device ID (0489:e156)

### DIFF
--- a/linux-6.14/drivers/bluetooth/btusb.c
+++ b/linux-6.14/drivers/bluetooth/btusb.c
@@ -616,6 +616,8 @@ static const struct usb_device_id quirks_table[] = {
 						     BTUSB_WIDEBAND_SPEECH },
 
 	/* MediaTek MT7902 Bluetooth devices */
+	{ USB_DEVICE(0x0489, 0xe156), .driver_info = BTUSB_MEDIATEK |
+						     BTUSB_WIDEBAND_SPEECH },
 	{ USB_DEVICE(0x13d3, 0x3579), .driver_info = BTUSB_MEDIATEK |
 						     BTUSB_WIDEBAND_SPEECH },
 	{ USB_DEVICE(0x13d3, 0x3580), .driver_info = BTUSB_MEDIATEK |

--- a/linux-6.15/drivers/bluetooth/btusb.c
+++ b/linux-6.15/drivers/bluetooth/btusb.c
@@ -644,6 +644,8 @@ static const struct usb_device_id quirks_table[] = {
 						     BTUSB_WIDEBAND_SPEECH },
 						     
 	/* MediaTek MT7902 Bluetooth devices */
+	{ USB_DEVICE(0x0489, 0xe156), .driver_info = BTUSB_MEDIATEK |
+						     BTUSB_WIDEBAND_SPEECH },
 	{ USB_DEVICE(0x13d3, 0x3579), .driver_info = BTUSB_MEDIATEK |
 						     BTUSB_WIDEBAND_SPEECH },
 	{ USB_DEVICE(0x13d3, 0x3580), .driver_info = BTUSB_MEDIATEK |

--- a/linux-6.16/drivers/bluetooth/btusb.c
+++ b/linux-6.16/drivers/bluetooth/btusb.c
@@ -645,6 +645,8 @@ static const struct usb_device_id quirks_table[] = {
 						     BTUSB_WIDEBAND_SPEECH },
 
 	/* MediaTek MT7902 Bluetooth devices */
+	{ USB_DEVICE(0x0489, 0xe156), .driver_info = BTUSB_MEDIATEK |
+						     BTUSB_WIDEBAND_SPEECH },
 	{ USB_DEVICE(0x13d3, 0x3579), .driver_info = BTUSB_MEDIATEK |
 						     BTUSB_WIDEBAND_SPEECH },
 	{ USB_DEVICE(0x13d3, 0x3580), .driver_info = BTUSB_MEDIATEK |

--- a/linux-6.17/drivers/bluetooth/btusb.c
+++ b/linux-6.17/drivers/bluetooth/btusb.c
@@ -616,6 +616,8 @@ static const struct usb_device_id quirks_table[] = {
 						     BTUSB_WIDEBAND_SPEECH },
 						     
     /* Additional MediaTek MT7902 Bluetooth devices */
+    { USB_DEVICE(0x0489, 0xe156), .driver_info = BTUSB_MEDIATEK |
+					     BTUSB_WIDEBAND_SPEECH },		     
     { USB_DEVICE(0x13d3, 0x3579), .driver_info = BTUSB_MEDIATEK |
 					     BTUSB_WIDEBAND_SPEECH },		     
     { USB_DEVICE(0x13d3, 0x3580), .driver_info = BTUSB_MEDIATEK |

--- a/linux-6.18/drivers/bluetooth/btusb.c
+++ b/linux-6.18/drivers/bluetooth/btusb.c
@@ -619,6 +619,8 @@ static const struct usb_device_id quirks_table[] = {
 						     BTUSB_WIDEBAND_SPEECH },
 						     
     /* Additional MediaTek MT7902 Bluetooth devices */
+    { USB_DEVICE(0x0489, 0xe156), .driver_info = BTUSB_MEDIATEK |
+					     BTUSB_WIDEBAND_SPEECH },		     
     { USB_DEVICE(0x13d3, 0x3579), .driver_info = BTUSB_MEDIATEK |
 					     BTUSB_WIDEBAND_SPEECH },		     
     { USB_DEVICE(0x13d3, 0x3580), .driver_info = BTUSB_MEDIATEK |

--- a/linux-6.19/drivers/bluetooth/btusb.c
+++ b/linux-6.19/drivers/bluetooth/btusb.c
@@ -627,6 +627,8 @@ static const struct usb_device_id quirks_table[] = {
 						     BTUSB_WIDEBAND_SPEECH },
 						     
     /* Additional MediaTek MT7902 Bluetooth devices */
+    { USB_DEVICE(0x0489, 0xe156), .driver_info = BTUSB_MEDIATEK |
+					     BTUSB_WIDEBAND_SPEECH },		     
     { USB_DEVICE(0x13d3, 0x3579), .driver_info = BTUSB_MEDIATEK |
 					     BTUSB_WIDEBAND_SPEECH },		     
     { USB_DEVICE(0x13d3, 0x3580), .driver_info = BTUSB_MEDIATEK |

--- a/linux-7.0/drivers/bluetooth/btusb.c
+++ b/linux-7.0/drivers/bluetooth/btusb.c
@@ -672,6 +672,8 @@ static const struct usb_device_id quirks_table[] = {
 	{ USB_DEVICE(0x13d3, 0x3606), .driver_info = BTUSB_MEDIATEK |
 						     BTUSB_WIDEBAND_SPEECH },
 	/* MediaTek MT7902 Bluetooth devices */
+	{ USB_DEVICE(0x0489, 0xe156), .driver_info = BTUSB_MEDIATEK |
+						     BTUSB_WIDEBAND_SPEECH },
 	{ USB_DEVICE(0x0e8d, 0x1ede), .driver_info = BTUSB_MEDIATEK |
 						     BTUSB_WIDEBAND_SPEECH },
 	{ USB_DEVICE(0x13d3, 0x3579), .driver_info = BTUSB_MEDIATEK |

--- a/linux-7.1/drivers/bluetooth/btusb.c
+++ b/linux-7.1/drivers/bluetooth/btusb.c
@@ -672,6 +672,8 @@ static const struct usb_device_id quirks_table[] = {
 	{ USB_DEVICE(0x13d3, 0x3606), .driver_info = BTUSB_MEDIATEK |
 						     BTUSB_WIDEBAND_SPEECH },
 	/* MediaTek MT7902 Bluetooth devices */
+	{ USB_DEVICE(0x0489, 0xe156), .driver_info = BTUSB_MEDIATEK |
+						     BTUSB_WIDEBAND_SPEECH },
 	{ USB_DEVICE(0x0e8d, 0x1ede), .driver_info = BTUSB_MEDIATEK |
 						     BTUSB_WIDEBAND_SPEECH },
 	{ USB_DEVICE(0x13d3, 0x3579), .driver_info = BTUSB_MEDIATEK |


### PR DESCRIPTION
## Summary
Add USB device ID `0489:e156` (Foxconn / Hon Hai) to the Bluetooth `quirks_table[]` in `btusb.c` across all kernel versions (6.14–7.1).

Without this entry, `btusb` does not recognize the Foxconn-branded MT7902 Bluetooth controller, so no MediaTek firmware is loaded and Bluetooth fails silently.

## Hardware Tested
- **Motherboard:** Gigabyte B850M Force WiFi6E
- **Wireless Module:** Foxconn / Hon Hai (USB 0489:e156, PCIe subsystem e13f)
- **WiFi chip (lspci):** MediaTek MT7902 [Filogic 310] (14c3:7902)
- **BT controller (hciconfig):** MediaTek, Inc. (70), HCI/LMP 5.2
- **Kernel:** 7.0.0-29-generic (Ubuntu)
- **Result:** Bluetooth hci0 UP RUNNING, scanning and pairing work

## Note
- This same USB ID (0489:e156) has been reported on other devices (e.g. HP EliteMini, see jetm/mediatek-mt7927-dkms#87) where the BT silicon identifies as MT6639. The `btusb.c` entry is chip-agnostic — it enables the MediaTek code path, and `btmtk.c` determines the actual chip at runtime via HCI.
 - Used AI Assistance - Google Gemini and Anthropic Claude.